### PR TITLE
Fix link to app-core in application-trait.md

### DIFF
--- a/src/application-trait.md
+++ b/src/application-trait.md
@@ -154,7 +154,7 @@ fn main() -> cosmic::iced::Result {
 }
 ```
 
-[app-core]: https://pop-os.github.io/libcosmic/cosmic/app/struct.Core.html
+[app-core]: https://pop-os.github.io/libcosmic/cosmic/struct.Core.html
 [app-trait]: https://pop-os.github.io/libcosmic/cosmic/app/trait.Application.html
 [builder-pattern]: https://rust-unofficial.github.io/patterns/patterns/creational/builder.html
 [cosmic-widget]: https://pop-os.github.io/libcosmic/cosmic/widget/index.html


### PR DESCRIPTION
For some reason /app link does not work for Core Link but for the others...